### PR TITLE
Résolution des 3 erreurs du rapport d'incidents

### DIFF
--- a/Denombrements/Program.cs
+++ b/Denombrements/Program.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Denombrements
 {
@@ -10,60 +6,115 @@ namespace Denombrements
     {
         static void Main(string[] args)
         {
-            int c = 1;
-            while (c != 0)
+            bool correct;
+            int choix = 1;
+
+            while (choix != 0)
             {
-                Console.WriteLine("Permutation ...................... 1");
-                Console.WriteLine("Arrangement ...................... 2");
-                Console.WriteLine("Combinaison ...................... 3");
-                Console.WriteLine("Quitter .......................... 0");
-                Console.Write("Choix :                            ");
-                c = int.Parse(Console.ReadLine());
+                correct = false;
+                while (!correct)
+                    try
+                    {
+                        Console.WriteLine("Permutation ...................... 1");
+                        Console.WriteLine("Arrangement ...................... 2");
+                        Console.WriteLine("Combinaison ...................... 3");
+                        Console.WriteLine("Quitter .......................... 0");
+                        Console.Write("Choix :                            ");
+                        choix = int.Parse(Console.ReadLine());
+                        if (!(choix == 0 || choix == 1 || choix == 2 || choix == 3))
+                            {
+                                Console.WriteLine("Erreur de saisie : Choisissez parmis les 4 possibilités !");
+                            }
+                        else
+                        {
+                            correct = true;
+                        }
+                    }
+                    catch
+                    {
+                        Console.WriteLine("Erreur de saisie");
+                    }
 
-                if (c == 0) { Environment.Exit(0); }
+                
+                if (choix == 0) { Environment.Exit(0); }
 
-                if (c == 1)
+                if (choix == 1)
                 {
-                    Console.Write("nombre total d'éléments à gérer = "); // le nombre d'éléments à gérer
-                    int n = int.Parse(Console.ReadLine()); // saisir le nombre
-                                                           // calcul de r
-                    long r = 1;
-                    for (int k = 1; k <= n; k++)
-                        r *= k;
-                    Console.WriteLine(n + "! = " + r);
+                    correct = false;
+                    while (!correct)
+                    {
+                        try
+                        {
+                            Console.Write("nombre total d'éléments à gérer = "); // le nombre d'éléments à gérer
+                            int n = int.Parse(Console.ReadLine()); // saisir le nombre
+                                                                   // calcul de r
+                            long r = 1;
+                            for (int k = 1; k <= n; k++)
+                                r *= k;
+                            Console.WriteLine(n + "! = " + r);
+                            correct = true;
+                        }
+                        catch
+                        {
+                            Console.WriteLine("Erreur de Saisie : Veuillez saisir un nombre entier!");
+                        }
+                    }
+                
+                }
+                else if (choix == 2)
+                {
+                    correct = false;
+                    while (!correct)
+                    {
+                        try
+                        {
+                            Console.Write("nombre total d'éléments à gérer = "); // le nombre d'éléments à gérer
+                            int t = int.Parse(Console.ReadLine()); // saisir le nombre
+                            Console.Write("nombre d'éléments dans le sous ensemble = "); // le sous ensemble
+                            int n = int.Parse(Console.ReadLine()); // saisir le nombre
+                                                                   // calcul de r
+                            long r = 1;
+                            for (int k = (t - n + 1); k <= t; k++)
+                                r *= k;
+                            //Console.WriteLine("résultat = " + (r1 / r2));
+                            Console.WriteLine("A(" + t + "/" + n + ") = " + r);
+                            correct = true;
+                        }
+                        catch
+                        {
+                            Console.WriteLine("Erreur de Saisie : Veuillez saisir un nombre entier!");
+                        }
+                    }
+                    
                 }
                 else
                 {
-                    if (c == 2)
+                    correct = false;
+                    while (!correct)
                     {
-                        Console.Write("nombre total d'éléments à gérer = "); // le nombre d'éléments à gérer
-                        int t = int.Parse(Console.ReadLine()); // saisir le nombre
-                        Console.Write("nombre d'éléments dans le sous ensemble = "); // le sous ensemble
-                        int n = int.Parse(Console.ReadLine()); // saisir le nombre
-                        // calcul de r
-                        long r = 1;
-                        for (int k = (t - n + 1); k <= t; k++)
-                            r *= k;
-                        //Console.WriteLine("résultat = " + (r1 / r2));
-                        Console.WriteLine("A(" + t + "/" + n + ") = " + r);
-                    }
-                    else
-                    {
-                        Console.Write("nombre total d'éléments à gérer = "); // le nombre d'éléments à gérer
-                        int t = int.Parse(Console.ReadLine()); // saisir le nombre
-                        Console.Write("nombre d'éléments dans le sous ensemble = "); // le sous ensemble
-                        int n = int.Parse(Console.ReadLine()); // saisir le nombre
-                        // calcul de r1
-                        long r1 = 1;
-                        for (int k = (t - n + 1); k <= t; k++)
-                            r1 *= k;
-                        // calcul de r2
-                        long r2 = 1;
-                        for (int k = 1; k <= n; k++)
-                            r2 *= k;
-                        // calcul de r3
-                        //Console.WriteLine("résultat = " + (r1 / r2));
-                        Console.WriteLine("C(" + t + "/" + n + ") = " + (r1 / r2));
+                        try
+                        {
+                            Console.Write("nombre total d'éléments à gérer = "); // le nombre d'éléments à gérer
+                            int t = int.Parse(Console.ReadLine()); // saisir le nombre
+                            Console.Write("nombre d'éléments dans le sous ensemble = "); // le sous ensemble
+                            int n = int.Parse(Console.ReadLine()); // saisir le nombre
+                                                                   // calcul de r1
+                            long r1 = 1;
+                            for (int k = (t - n + 1); k <= t; k++)
+                                r1 *= k;
+                            // calcul de r2
+                            long r2 = 1;
+                            for (int k = 1; k <= n; k++)
+                                r2 *= k;
+                            // calcul de r3
+                            //Console.WriteLine("résultat = " + (r1 / r2));
+                            Console.WriteLine("C(" + t + "/" + n + ") = " + (r1 / r2));
+                            correct = true;
+                        }
+                        catch
+                        {
+                            Console.WriteLine("Erreur de Saisie : Veuillez saisir un nombre entier!");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Résolution de l'erreur  1 "erreur de saisie" (lorsque l'entrée est un entier autre que ceux proposés), ainsi que de l'erreur 2 "erreur de saisie" (lorsque, dans le menu, l'entrée est un nombre réel et/ou une lettre ), et résolution de l'erreur 3 "entrez un entier" et nouvelle saisie (lorsque l'entrée lors de la saisie d'un calcul est autre qu'un entier).